### PR TITLE
Update Abstract.php

### DIFF
--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -1149,7 +1149,7 @@ abstract class Doctrine_Query_Abstract
         $copy->free();
 
         if ($componentsBefore !== $componentsAfter) {
-            return array_diff_assoc($componentsAfter, $componentsBefore);
+            return @array_diff($componentsAfter, $componentsBefore);
         } else {
             return $componentsAfter;
         }


### PR DESCRIPTION
@mymac80 @rickpelletier 

`array_diff_assoc` still throws PHP Notice with PHP 5.4.  This change fixes that.
